### PR TITLE
upgrading wrtc to avoid node-gyp error while installing on ubuntu 16.04

### DIFF
--- a/node/package.json
+++ b/node/package.json
@@ -40,7 +40,7 @@
     "pubnub": "3.7.0",
     "q": "^1.0.1",
     "xmlhttprequest": "^1.6.0",
-    "wrtc": "0.0.55",
+    "wrtc": "0.0.60",
     "sinch-ticketgen": "0.0.6"
   },
   "license": "Proprietary",


### PR DESCRIPTION
I got this wrtc error when trying to install on Ubuntu 16.04  which happens in #4 and #1 
The issue is fixed when upgrading to wrtc@0.0.60 instead of wrtc@0.0.55

The Error

```
gyp: /home/op/.node-gyp/4.4.5/common.gypi not found (cwd: /home/op/sinch-js-rtc/node/node_modules/wrtc) while reading 
includes of binding.gyp while trying to load binding.gyp
gyp ERR! configure error 
gyp ERR! stack Error: `gyp` failed with exit code: 1
gyp ERR! stack     at ChildProcess.onCpExit (/home/op/sinch-js-rtc/node/node_modules/wrtc/node_modules/node-gyp/lib/co
nfigure.js:343:16)
gyp ERR! stack     at emitTwo (events.js:87:13)
gyp ERR! stack     at ChildProcess.emit (events.js:172:7)
gyp ERR! stack     at Process.ChildProcess._handle.onexit (internal/child_process.js:200:12)
gyp ERR! System Linux 4.4.0-31-generic
gyp ERR! command "/home/op/.nvm/versions/node/v4.4.5/bin/node" "/home/op/sinch-js-rtc/node/node_modules/wrtc/node_modu
les/node-gyp/bin/node-gyp.js" "configure" "--fallback-to-build" "--module=/home/op/sinch-js-rtc/node/node_modules/wrtc
/build/wrtc/v0.0.55/Release/node-v46-linux-x64/wrtc.node" "--module_name=wrtc" "--module_path=/home/op/sinch-js-rtc/no
de/node_modules/wrtc/build/wrtc/v0.0.55/Release/node-v46-linux-x64"
gyp ERR! cwd /home/op/sinch-js-rtc/node/node_modules/wrtc
gyp ERR! node -v v4.4.5
gyp ERR! node-gyp -v v1.0.3
gyp ERR! not ok 
node-pre-gyp ERR! build error 
node-pre-gyp ERR! stack Error: Failed to execute '/home/op/.nvm/versions/node/v4.4.5/bin/node /home/op/sinch-js-rtc/no
de/node_modules/wrtc/node_modules/node-gyp/bin/node-gyp.js configure --fallback-to-build --module=/home/op/sinch-js-rt
c/node/node_modules/wrtc/build/wrtc/v0.0.55/Release/node-v46-linux-x64/wrtc.node --module_name=wrtc --module_path=/hom
e/op/sinch-js-rtc/node/node_modules/wrtc/build/wrtc/v0.0.55/Release/node-v46-linux-x64' (1)
node-pre-gyp ERR! stack     at ChildProcess.<anonymous> (/home/op/sinch-js-rtc/node/node_modules/wrtc/node_modules/nod
e-pre-gyp/lib/util/compile.js:73:29)
node-pre-gyp ERR! stack     at emitTwo (events.js:87:13)
node-pre-gyp ERR! stack     at ChildProcess.emit (events.js:172:7)
node-pre-gyp ERR! stack     at maybeClose (internal/child_process.js:827:16)
node-pre-gyp ERR! stack     at Process.ChildProcess._handle.onexit (internal/child_process.js:211:5)
node-pre-gyp ERR! System Linux 4.4.0-31-generic
node-pre-gyp ERR! command "/home/op/.nvm/versions/node/v4.4.5/bin/node" "/home/op/sinch-js-rtc/node/node_modules/wrtc/
node_modules/.bin/node-pre-gyp" "install" "--fallback-to-build"
node-pre-gyp ERR! cwd /home/op/sinch-js-rtc/node/node_modules/wrtc
node-pre-gyp ERR! node -v v4.4.5
node-pre-gyp ERR! node-pre-gyp -v v0.6.4
node-pre-gyp ERR! not ok 
Failed to execute '/home/op/.nvm/versions/node/v4.4.5/bin/node /home/op/sinch-js-rtc/node/node_modules/wrtc/node_modul
es/node-gyp/bin/node-gyp.js configure --fallback-to-build --module=/home/op/sinch-js-rtc/node/node_modules/wrtc/build/
wrtc/v0.0.55/Release/node-v46-linux-x64/wrtc.node --module_name=wrtc --module_path=/home/op/sinch-js-rtc/node/node_mod
ules/wrtc/build/wrtc/v0.0.55/Release/node-v46-linux-x64' (1)
npm verb unsafe-perm in lifecycle true
npm info wrtc@0.0.55 Failed to exec install script
npm verb unlock done using /home/op/.npm/_locks/wrtc-23de00d07a7a44af.lock for /home/op/sinch-js-rtc/node/node_modules
/wrtc
npm verb stack Error: wrtc@0.0.55 install: `node-pre-gyp install --fallback-to-build`
npm verb stack Exit status 1
npm verb stack     at EventEmitter.<anonymous> (/home/op/.nvm/versions/node/v4.4.5/lib/node_modules/npm/lib/utils/life
cycle.js:217:16)
npm verb stack     at emitTwo (events.js:87:13)
npm verb stack     at EventEmitter.emit (events.js:172:7)
npm verb stack     at ChildProcess.<anonymous> (/home/op/.nvm/versions/node/v4.4.5/lib/node_modules/npm/lib/utils/spaw
n.js:24:14)
npm verb stack     at emitTwo (events.js:87:13)
npm verb stack     at ChildProcess.emit (events.js:172:7)
npm verb stack     at maybeClose (internal/child_process.js:827:16)
npm verb stack     at Process.ChildProcess._handle.onexit (internal/child_process.js:211:5)
npm verb pkgid wrtc@0.0.55
npm verb cwd /home/op/sinch-js-rtc/node
npm ERR! Linux 4.4.0-31-generic
npm ERR! argv "/home/op/.nvm/versions/node/v4.4.5/bin/node" "/home/op/.nvm/versions/node/v4.4.5/bin/npm" "install" "--
verbose"
npm ERR! node v4.4.5
npm ERR! npm  v2.15.5
npm ERR! code ELIFECYCLE

npm ERR! wrtc@0.0.55 install: `node-pre-gyp install --fallback-to-build`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the wrtc@0.0.55 install script 'node-pre-gyp install --fallback-to-build'.
npm ERR! This is most likely a problem with the wrtc package,
npm ERR! not with npm itself.
npm ERR! Tell the author that this fails on your system:
npm ERR!     node-pre-gyp install --fallback-to-build
npm ERR! You can get information on how to open an issue for this project with:
npm ERR!     npm bugs wrtc
npm ERR! Or if that isn't available, you can get their info via:
npm ERR! 
npm ERR!     npm owner ls wrtc
npm ERR! There is likely additional logging output above.
npm verb exit [ 1, true ]
npm verb unbuild node_modules/wrtc
npm info preuninstall wrtc@0.0.55
npm info uninstall wrtc@0.0.55
npm verb unbuild rmStuff wrtc@0.0.55 from /home/op/sinch-js-rtc/node/node_modules
npm info postuninstall wrtc@0.0.55
npm verb gentlyRm don't care about contents; nuking /home/op/sinch-js-rtc/node/node_modules/wrtc

npm ERR! Please include the following file with any support request:
npm ERR!     /home/op/sinch-js-rtc/node/npm-debug.log

```

after upgrading to wrtc@0.0.60

```
$ npm install
npm WARN package.json sinch-rtc@1.4.2 license should be a valid SPDX license expression
npm WARN deprecated graceful-fs@3.0.8: graceful-fs v3.0.0 and before will fail on node releases >= v7.0. Please update to graceful-fs@^4.0.0 as soon as possible. Use 'npm ls graceful-fs' to find it in the tree.
|
> wrtc@0.0.60 install /home/op/sinch-js-rtc/node/node_modules/wrtc
> node-pre-gyp install --fallback-to-build

[wrtc] Success: "/home/op/sinch-js-rtc/node/node_modules/wrtc/build/wrtc/v0.0.60/Release/node-v46-linux-x64/wrtc.node" is installed via remote
wrtc@0.0.60 node_modules/wrtc
├── nopt@2.2.1 (abbrev@1.0.9)
├── nan@2.4.0
├── node-static-alias@0.1.3 (node-static@0.7.7)
├── fs-extra@0.18.4 (jsonfile@2.3.1, graceful-fs@3.0.8, rimraf@2.5.3)
└── node-gyp@3.4.0 (rimraf@2.5.3, graceful-fs@4.1.4, semver@5.3.0, osenv@0.1.3, which@1.2.10, minimatch@3.0.2, glob@7.0.5, fstream@1.0.10, mkdirp@0.5.1, tar@2.2.1, npmlog@3.1.2, request@2.73.0, path-array@1.0.1)

```

Signed-off-by: Yahya yahya@adjoin.io
