### PR TITLE
Fix display of login form & API errors on PSTN example page 

### DIFF
--- a/samples/SinchPSTNsample/PSTNsample.js
+++ b/samples/SinchPSTNsample/PSTNsample.js
@@ -9,6 +9,7 @@ var showUI = function() {
 	$('div#userInfo').css('display', 'inline');
 	$('h3#login').css('display', 'none');
 	$('span#username').text(global_username);
+	$('div.frame').not('#chromeFileWarning').show();
 }
 
 
@@ -210,6 +211,7 @@ var handleError = function(error) {
 
 	//Show error
 	$('div.error').text(error.message);
+	$('div.frame').not('#chromeFileWarning').show();
 	$('div.error').show();
 }
 

--- a/samples/SinchPSTNsample/style/style.css
+++ b/samples/SinchPSTNsample/style/style.css
@@ -48,6 +48,7 @@ div.frame.small {
 	border-width: 0px 1px 0px 0px;
 	border-color: #B0B0B0;
 	padding: 0px;
+	display: inline;
 }
 
 div.frame.big {


### PR DESCRIPTION
This Purr Request fixes the following two UI glitches:
- Loading the example PSTN page is not displaying the login form on page load
- API/auth errors are not shown to user as the error layer’s parent div id hidden

Does it look ok?